### PR TITLE
Add functionality for reading needed types of .obj files

### DIFF
--- a/history.md
+++ b/history.md
@@ -2,6 +2,28 @@
 
 Here you can see some documentation about the project history.
 
+#### 2019-11-27
+I added the smooth group to the `Wavefront` data structure. 
+I assume I will need it later (when light is involved) for gouraud shading vs phong shading.
+I also refactored the process of creating the `Mesh`.
+Reading .obj files is done for every type I probably will need.
+At the moment only `SimpleMesh` and `SimpleIndexedMesh` is possible to create from an .obj file, the other ones will follow soon.
+
+#### 2019-11-25
+I added some tests for the wavefront read file process.
+
+#### 2019-11-24
+I modified the read .obj file / create `Wavefront` process.
+Triangulated geometry with the following definitions are now supported:
+* vertex - face
+* vertex - normal - face
+* vertex - texture - face
+* vertex - texture - normal - face
+
+Tests are missing, yet.
+Transformation from `Wavefront` to Mesh is missing, yet.
+I'm not really happy with the rewrite (No error handling, no validation, not so nice code).
+
 #### 2019-11-22
 I read how to publish a lib locally for testing the wavefront-reader.
 I modified the `build.sbt` and now I can use `sbt publishLocal` for this.

--- a/src/main/scala/org/sorted/chaos/model/Wavefront.scala
+++ b/src/main/scala/org/sorted/chaos/model/Wavefront.scala
@@ -1,62 +1,180 @@
 package org.sorted.chaos.model
 
-import org.sorted.chaos.utilities.FileReader
+import org.slf4j.LoggerFactory
 
+/**
+  * This model describes each index for one point of a triangle.
+  *
+  * @param vertexIndex the index of the vertex
+  * @param textureIndex the index of the texture (optional)
+  * @param normalIndex the index of the normal (optional)
+  */
+final case class Index(vertexIndex: Int, textureIndex: Option[Int], normalIndex: Option[Int])
+
+/**
+  *  This model describes the face (triangle) definition of the .obj file starting with `f ...`. There are
+  *  several abilities possible
+  *  Examples:
+  *  * `f 7 6 8` - only vertices
+  *  * f 1/1 2/2 3/3 4/4 - vertex & texture
+  *  * `f 1//3 4//5 2//8` - vertex & normals
+  *  * `f 28/28/28 79/29/29 78/27/27` - vertex, texture & normal
+  *
+  * @param index1 The indexes for the first point of the triangle
+  * @param index2 The indexes for the second point of the triangle
+  * @param index3 The indexes for the third point of the triangle
+  */
+final case class Triangle(index1: Index, index2: Index, index3: Index) {
+  def asVector: Vector[Index] = Vector(index1, index2, index3)
+}
+
+/**
+  * This model describes the vertex/normal definition of the .obj file starting with `v ...` or `vn ...`
+  * Example
+  * * `v 0.230970 -1.000000 0.095671` (vertex)
+  * or
+  * * `vn 0.6894 -0.6657 0.2855` (normal)
+  * @param x coordinate
+  * @param y coordinate
+  * @param z coordinate
+  */
 final case class Point(x: Float, y: Float, z: Float) {
   def toArray: Array[Float] = Array(x, y, z)
 }
 
-final case class Face(indexOfPoint1: Int, indexOfPoint2: Int, indexOfPoint3: Int) {
-  def toArray: Array[Int] = Array(indexOfPoint1, indexOfPoint2, indexOfPoint3)
-}
+/**
+  * This model describes the texture definition of the .obj file starting with `vt ...`
+  * Example:
+  * * `vt 0.609836 0.758661`
+  * @param u texture coordinate
+  * @param v texture coordinate
+  */
+final case class UVCoordinate(u: Float, v: Float)
 
-final case class Wavefront(vertices: Vector[Point], faces: Vector[Face])
+/**
+  * This is the internal model of the .obj file, containing all the relevant data
+  *
+  * @param vertices a list of vertex definitions
+  * @param triangles a list of triangle definitions
+  * @param normals a list of normal definitions
+  * @param textures a list of texture definitions
+  */
+final case class Wavefront(
+    vertices: Vector[Point],
+    triangles: Vector[Triangle],
+    normals: Vector[Point],
+    textures: Vector[UVCoordinate],
+    smoothShading: Boolean
+)
 
 object Wavefront {
-  private val Space       = " "
-  private val VertexToken = "v"
-  private val FaceToken   = "f"
+  private val Logger = LoggerFactory.getLogger(this.getClass)
 
-  private def empty = Wavefront(Vector.empty[Point], Vector.empty[Face])
+  private val Vertex        = "v"
+  private val Face          = "f"
+  private val Texture       = "vt"
+  private val Normal        = "vn"
+  private val Space         = " "
+  private val SmoothShading = "s"
 
-  def from(filename: String): Wavefront = {
-    val lines = FileReader.read(filename)
-    lines.foldLeft(Wavefront.empty) { (accumulator, line) =>
+  private val VertexTextureNormalPattern = """(\d+)/(\d+)/(\d+)""".r
+  private val VertexTexturePattern       = """(\d+)/(\d+)""".r
+  private val VertexNormalPattern        = """(\d+)//(\d+)""".r
+  private val VertexPattern              = """(\d+)""".r
+
+  private[model] def empty =
+    Wavefront(
+      vertices      = Vector.empty[Point],
+      triangles     = Vector.empty[Triangle],
+      normals       = Vector.empty[Point],
+      textures      = Vector.empty[UVCoordinate],
+      smoothShading = false
+    )
+
+  def from(lines: Vector[String]): Wavefront =
+    lines.foldLeft(Wavefront.empty) { (accWavefront, line) =>
       {
-        val parts = splitLine(line)
-        parts(0) match {
-          case VertexToken =>
-            createVertex(accumulator, parts)
-          case FaceToken =>
-            createFace(accumulator, parts)
+        val token = line.take(2).trim
+        token match {
+          case Vertex =>
+            val point = createPointFrom(line)
+            accWavefront.copy(vertices = accWavefront.vertices :+ point)
+          case Face =>
+            val triangle = createTriangleFrom(line)
+            accWavefront.copy(triangles = accWavefront.triangles :+ triangle)
+          case Texture =>
+            val uvCoordinate = createUVCoordinateFrom(line)
+            accWavefront.copy(textures = accWavefront.textures :+ uvCoordinate)
+          case Normal =>
+            val point = createPointFrom(line)
+            accWavefront.copy(normals = accWavefront.normals :+ point)
+          case SmoothShading =>
+            val smoothShading = isSmoothShading(line)
+            accWavefront.copy(smoothShading = smoothShading)
           case _ =>
-            accumulator
+            accWavefront
         }
       }
     }
+
+  // TODO refactor + Error handling
+  private def createTriangleFrom(line: String) = {
+    val parts = line.split(Space).tail
+    val indexes = parts.map {
+      case VertexTextureNormalPattern(vertex, texture, normal) =>
+        Index(
+          vertexIndex  = vertex.toInt,
+          textureIndex = Some(texture.toInt),
+          normalIndex  = Some(normal.toInt)
+        )
+      case VertexTexturePattern(vertex, texture) =>
+        Index(
+          vertexIndex  = vertex.toInt,
+          textureIndex = Some(texture.toInt),
+          normalIndex  = None
+        )
+      case VertexNormalPattern(vertex, normal) =>
+        Index(
+          vertexIndex  = vertex.toInt,
+          textureIndex = None,
+          normalIndex  = Some(normal.toInt)
+        )
+      case VertexPattern(vertex) =>
+        Index(
+          vertexIndex  = vertex.toInt,
+          textureIndex = None,
+          normalIndex  = None
+        )
+    }
+
+    Triangle(
+      indexes(0),
+      indexes(1),
+      indexes(2)
+    )
   }
 
-  private def splitLine(line: String) = line.split(Space).toVector
-
-  private def createVertex(accumulator: Wavefront, parts: Vector[String]) = {
-    val vertex = Point(
-      parts(1).toFloat,
-      parts(2).toFloat,
-      parts(3).toFloat
-    )
-    Wavefront(accumulator.vertices :+ vertex, accumulator.faces)
+  private def isSmoothShading(line: String) = {
+    val lineParts = line.split(Space)
+    if (lineParts(1) == "1") {
+      true
+    } else {
+      false
+    }
   }
 
-  /**
-    * We subtract 1 from the index because .obj files are count from 1 but the index
-    * in the scala Vector data structure starts with 0
-    */
-  private def createFace(accumulator: Wavefront, parts: Vector[String]) = {
-    val face = Face(
-      parts(1).toInt - 1,
-      parts(2).toInt - 1,
-      parts(3).toInt - 1
-    )
-    Wavefront(accumulator.vertices, accumulator.faces :+ face)
+  private def createPointFrom(line: String) = {
+    val numbers = extractFloatsFrom(line)
+    Point(numbers(0), numbers(1), numbers(2))
+  }
+
+  private def createUVCoordinateFrom(line: String) = {
+    val numbers = extractFloatsFrom(line)
+    UVCoordinate(numbers(0), numbers(1))
+  }
+
+  private def extractFloatsFrom(line: String) = {
+    val lineParts = line.split(Space)
+    lineParts.tail.map(_.toFloat)
   }
 }

--- a/src/main/scala/org/sorted/chaos/process/SimpleIndexedMesh.scala
+++ b/src/main/scala/org/sorted/chaos/process/SimpleIndexedMesh.scala
@@ -6,13 +6,17 @@ final case class SimpleIndexedMesh(vertices: Array[Float], color: Array[Float], 
 
 object SimpleIndexedMesh {
   def from(wavefront: Wavefront, color: SolidColor): SimpleIndexedMesh = {
-    val wavefrontVertices = wavefront.vertices
-    val wavefrontFaces    = wavefront.faces
+    val wavefrontVertices  = wavefront.vertices
+    val wavefrontTriangles = wavefront.triangles
 
     val vertices   = wavefrontVertices.flatMap(point => point.toArray).toArray
     val colorArray = color.toArray
     val col        = Array.tabulate(vertices.length)(index => colorArray(index % 3))
-    val indexes    = wavefrontFaces.flatMap(face => face.toArray).toArray
+    val indexes = wavefrontTriangles
+      .flatMap(triangle => {
+        triangle.asVector.map(_.vertexIndex - 1) // subtract 1 because of starting index obj vs scala (collection)
+      })
+      .toArray
     SimpleIndexedMesh(vertices, col, indexes)
   }
 }

--- a/src/main/scala/org/sorted/chaos/process/SimpleMesh.scala
+++ b/src/main/scala/org/sorted/chaos/process/SimpleMesh.scala
@@ -19,18 +19,19 @@ object SimpleMesh {
   private def empty = SimpleMesh(Array.emptyFloatArray, Array.emptyFloatArray)
 
   def from(wavefront: Wavefront, color: SolidColor): SimpleMesh = {
-    val wavefrontVertices = wavefront.vertices
-    val wavefrontFaces    = wavefront.faces
+    val wavefrontVertices  = wavefront.vertices
+    val wavefrontTriangles = wavefront.triangles
 
-    wavefrontFaces.foldLeft(SimpleMesh.empty) { (accumulator, triangleDef) =>
+    wavefrontTriangles.foldLeft(SimpleMesh.empty) { (accumulator, triangleDef) =>
       {
-        val index1 = triangleDef.indexOfPoint1
-        val index2 = triangleDef.indexOfPoint2
-        val index3 = triangleDef.indexOfPoint3
+        val index1 = triangleDef.index1
+        val index2 = triangleDef.index2
+        val index3 = triangleDef.index3
 
-        val point1 = wavefrontVertices(index1)
-        val point2 = wavefrontVertices(index2)
-        val point3 = wavefrontVertices(index3)
+        // we have to subtract one because .obj index starts from 1, Scala Collection index starts from 0
+        val point1 = wavefrontVertices(index1.vertexIndex - 1)
+        val point2 = wavefrontVertices(index2.vertexIndex - 1)
+        val point3 = wavefrontVertices(index3.vertexIndex - 1)
 
         SimpleMesh(
           vertices = accumulator.vertices ++ point1.toArray ++ point2.toArray ++ point3.toArray,

--- a/src/test/scala/org/sorted/chaos/model/WavefrontTest.scala
+++ b/src/test/scala/org/sorted/chaos/model/WavefrontTest.scala
@@ -4,33 +4,199 @@ import org.scalatest.{ Matchers, WordSpec }
 
 class WavefrontTest extends WordSpec with Matchers {
   "A Wavefront" should {
-    "be created from a text file" in {
-      val actual = Wavefront.from("simple-cube.obj")
+
+    "handle a broken .obj file" in {
+      val input = Vector(
+        "v 1.0 1.0",
+        "v 4.0 1.0 0.0",
+        "v 4.0 4.0 0.0",
+        "v 1.0 4.0 0.0",
+        "f 1 2 2",
+        "f 1 3 4"
+      )
+
+      an[ArrayIndexOutOfBoundsException] should be thrownBy Wavefront.from(input)
+    }
+
+    "handle unused/undefined tokens" in {
+      val input = Vector(
+        "# This is a comment",
+        "o MyAwesomeObjectName"
+      )
+
+      val actual = Wavefront.from(input)
+      actual shouldBe Wavefront.empty
+    }
+
+    "transform lines from an .obj file to a wavefront data structure - vertices and faces" in {
+      val input = Vector(
+        "v 1.0 1.0 0.0",
+        "v 4.0 1.0 0.0",
+        "v 4.0 4.0 0.0",
+        "v 1.0 4.0 0.0",
+        "s off",
+        "f 1 2 3",
+        "f 1 3 4"
+      )
+
+      val actual = Wavefront.from(input)
       actual shouldBe Wavefront(
-        Vector(
-          Point(1.0f, 1.0f, -1.0f),
-          Point(1.0f, -1.0f, -1.0f),
-          Point(1.0f, 1.0f, 1.0f),
-          Point(1.0f, -1.0f, 1.0f),
-          Point(-1.0f, 1.0f, -1.0f),
-          Point(-1.0f, -1.0f, -1.0f),
-          Point(-1.0f, 1.0f, 1.0f),
-          Point(-1.0f, -1.0f, 1.0f)
+        vertices = Vector(
+          Point(1.0f, 1.0f, 0.0f),
+          Point(4.0f, 1.0f, 0.0f),
+          Point(4.0f, 4.0f, 0.0f),
+          Point(1.0f, 4.0f, 0.0f)
         ),
-        Vector(
-          Face(4, 2, 0),
-          Face(2, 7, 3),
-          Face(6, 5, 7),
-          Face(1, 7, 5),
-          Face(0, 3, 1),
-          Face(4, 1, 5),
-          Face(4, 6, 2),
-          Face(2, 6, 7),
-          Face(6, 4, 5),
-          Face(1, 3, 7),
-          Face(0, 2, 3),
-          Face(4, 0, 1)
-        )
+        triangles = Vector(
+          Triangle(
+            Index(1, None, None),
+            Index(2, None, None),
+            Index(3, None, None)
+          ),
+          Triangle(
+            Index(1, None, None),
+            Index(3, None, None),
+            Index(4, None, None)
+          )
+        ),
+        normals       = Vector.empty[Point],
+        textures      = Vector.empty[UVCoordinate],
+        smoothShading = false
+      )
+    }
+
+    "transform lines from an .obj file to a wavefront data structure - vertices, textures and faces" in {
+      val input = Vector(
+        "v 1.0 1.0 0.0",
+        "v 4.0 1.0 0.0",
+        "v 4.0 4.0 0.0",
+        "v 1.0 4.0 0.0",
+        "vt 0.0 0.0",
+        "vt 1.0 0.0",
+        "vt 1.0 1.0",
+        "vt 0.0 1.0",
+        "s off",
+        "f 1/1 2/2 3/3",
+        "f 1/1 3/3 4/4"
+      )
+
+      val actual = Wavefront.from(input)
+      actual shouldBe Wavefront(
+        vertices = Vector(
+          Point(1.0f, 1.0f, 0.0f),
+          Point(4.0f, 1.0f, 0.0f),
+          Point(4.0f, 4.0f, 0.0f),
+          Point(1.0f, 4.0f, 0.0f)
+        ),
+        triangles = Vector(
+          Triangle(
+            Index(1, Some(1), None),
+            Index(2, Some(2), None),
+            Index(3, Some(3), None)
+          ),
+          Triangle(
+            Index(1, Some(1), None),
+            Index(3, Some(3), None),
+            Index(4, Some(4), None)
+          )
+        ),
+        normals = Vector.empty[Point],
+        textures = Vector(
+          UVCoordinate(0.0f, 0.0f),
+          UVCoordinate(1.0f, 0.0f),
+          UVCoordinate(1.0f, 1.0f),
+          UVCoordinate(0.0f, 1.0f)
+        ),
+        smoothShading = false
+      )
+    }
+
+    "transform lines from an .obj file to a wavefront data structure - vertices, normals and faces (smoothShading = true)" in {
+      val input = Vector(
+        "v 1.0 1.0 0.0",
+        "v 4.0 1.0 0.0",
+        "v 4.0 4.0 0.0",
+        "v 1.0 4.0 0.0",
+        "vn 0.0 0.0 1.0",
+        "s 1",
+        "f 1//1 2//1 3//1",
+        "f 1//1 3//1 4//1"
+      )
+
+      val actual = Wavefront.from(input)
+      actual shouldBe Wavefront(
+        vertices = Vector(
+          Point(1.0f, 1.0f, 0.0f),
+          Point(4.0f, 1.0f, 0.0f),
+          Point(4.0f, 4.0f, 0.0f),
+          Point(1.0f, 4.0f, 0.0f)
+        ),
+        triangles = Vector(
+          Triangle(
+            Index(1, None, Some(1)),
+            Index(2, None, Some(1)),
+            Index(3, None, Some(1))
+          ),
+          Triangle(
+            Index(1, None, Some(1)),
+            Index(3, None, Some(1)),
+            Index(4, None, Some(1))
+          )
+        ),
+        normals = Vector(
+          Point(0.0f, 0.0f, 1.0f)
+        ),
+        textures      = Vector.empty[UVCoordinate],
+        smoothShading = true
+      )
+    }
+
+    "transform lines from an .obj file to a wavefront data structure - vertices, textures, normals and faces" in {
+      val input = Vector(
+        "v 1.0 1.0 0.0",
+        "v 4.0 1.0 0.0",
+        "v 4.0 4.0 0.0",
+        "v 1.0 4.0 0.0",
+        "vt 0.0 0.0",
+        "vt 1.0 0.0",
+        "vt 1.0 1.0",
+        "vt 0.0 1.0",
+        "vn 0.0 0.0 1.0",
+        "s off",
+        "f 1/1/1 2/2/1 3/3/1",
+        "f 1/1/1 3/3/1 4/4/1"
+      )
+
+      val actual = Wavefront.from(input)
+      actual shouldBe Wavefront(
+        vertices = Vector(
+          Point(1.0f, 1.0f, 0.0f),
+          Point(4.0f, 1.0f, 0.0f),
+          Point(4.0f, 4.0f, 0.0f),
+          Point(1.0f, 4.0f, 0.0f)
+        ),
+        triangles = Vector(
+          Triangle(
+            Index(1, Some(1), Some(1)),
+            Index(2, Some(2), Some(1)),
+            Index(3, Some(3), Some(1))
+          ),
+          Triangle(
+            Index(1, Some(1), Some(1)),
+            Index(3, Some(3), Some(1)),
+            Index(4, Some(4), Some(1))
+          )
+        ),
+        normals = Vector(
+          Point(0.0f, 0.0f, 1.0f)
+        ),
+        textures = Vector(
+          UVCoordinate(0.0f, 0.0f),
+          UVCoordinate(1.0f, 0.0f),
+          UVCoordinate(1.0f, 1.0f),
+          UVCoordinate(0.0f, 1.0f)
+        ),
+        smoothShading = false
       )
     }
   }

--- a/src/test/scala/org/sorted/chaos/process/SimpleIndexedMeshTest.scala
+++ b/src/test/scala/org/sorted/chaos/process/SimpleIndexedMeshTest.scala
@@ -1,7 +1,7 @@
 package org.sorted.chaos.process
 
 import org.scalatest.{ Matchers, WordSpec }
-import org.sorted.chaos.model.{ Face, Point, Wavefront }
+import org.sorted.chaos.model.{ Index, Point, Triangle, UVCoordinate, Wavefront }
 
 class SimpleIndexedMeshTest extends WordSpec with Matchers {
   "A SimpleIndexedMesh" should {
@@ -9,19 +9,37 @@ class SimpleIndexedMeshTest extends WordSpec with Matchers {
       val vertices = Vector(
         Point(1.0f, 1.0f, 0.0f),
         Point(4.0f, 1.0f, 0.0f),
-        Point(4.0f, 5.0f, 0.0f),
-        Point(1.0f, 5.0f, 0.0f)
+        Point(4.0f, 4.0f, 0.0f),
+        Point(1.0f, 4.0f, 0.0f)
       )
-      val faces     = Vector(Face(0, 2, 3), Face(0, 1, 2))
-      val wavefront = Wavefront(vertices, faces)
-      val color     = SolidColor(0.3f, 0.4f, 0.5f)
+      val triangles = Vector(
+        Triangle(
+          Index(1, None, None),
+          Index(2, None, None),
+          Index(3, None, None)
+        ),
+        Triangle(
+          Index(1, None, None),
+          Index(3, None, None),
+          Index(4, None, None)
+        )
+      )
+
+      val wavefront = Wavefront(
+        vertices      = vertices,
+        triangles     = triangles,
+        normals       = Vector.empty[Point],
+        textures      = Vector.empty[UVCoordinate],
+        smoothShading = false
+      )
+      val color = SolidColor(0.3f, 0.4f, 0.5f)
 
       val actual = SimpleIndexedMesh.from(wavefront, color)
-      actual.indexes should contain theSameElementsInOrderAs Array(0, 2, 3, 0, 1, 2)
+      actual.indexes should contain theSameElementsInOrderAs Array(0, 1, 2, 0, 2, 3)
       actual.color should contain theSameElementsInOrderAs Array(0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f, 0.3f, 0.4f,
         0.5f)
-      actual.vertices should contain theSameElementsInOrderAs Array(1.0f, 1.0f, 0.0f, 4.0f, 1.0f, 0.0f, 4.0f, 5.0f, 0.0f, 1.0f,
-        5.0f, 0.0f)
+      actual.vertices should contain theSameElementsInOrderAs Array(1.0f, 1.0f, 0.0f, 4.0f, 1.0f, 0.0f, 4.0f, 4.0f, 0.0f, 1.0f,
+        4.0f, 0.0f)
     }
   }
 }

--- a/src/test/scala/org/sorted/chaos/process/SimpleMeshTest.scala
+++ b/src/test/scala/org/sorted/chaos/process/SimpleMeshTest.scala
@@ -1,23 +1,44 @@
 package org.sorted.chaos.process
 
 import org.scalatest.{ Matchers, WordSpec }
-import org.sorted.chaos.model.{ Face, Point, Wavefront }
+import org.sorted.chaos.model.{ Index, Point, Triangle, UVCoordinate, Wavefront }
 
 class SimpleMeshTest extends WordSpec with Matchers {
   "A SimpleMesh" should {
     "be created from a wavefront and a color definition" in {
       val vertices = Vector(
-        Point(1.0f, 1.0f, 1.0f),
-        Point(2.0f, 2.0f, 2.0f),
-        Point(3.0f, 3.0f, 3.0f)
+        Point(1.0f, 1.0f, 0.0f),
+        Point(4.0f, 1.0f, 0.0f),
+        Point(4.0f, 4.0f, 0.0f),
+        Point(1.0f, 4.0f, 0.0f)
       )
-      val faces     = Vector(Face(2, 0, 1))
-      val wavefront = Wavefront(vertices, faces)
-      val color     = SolidColor(0.3f, 0.4f, 0.5f)
+      val triangles = Vector(
+        Triangle(
+          Index(1, None, None),
+          Index(2, None, None),
+          Index(3, None, None)
+        ),
+        Triangle(
+          Index(1, None, None),
+          Index(3, None, None),
+          Index(4, None, None)
+        )
+      )
+
+      val wavefront = Wavefront(
+        vertices      = vertices,
+        triangles     = triangles,
+        normals       = Vector.empty[Point],
+        textures      = Vector.empty[UVCoordinate],
+        smoothShading = false
+      )
+      val color = SolidColor(0.3f, 0.4f, 0.5f)
 
       val actual = SimpleMesh.from(wavefront, color)
-      actual.vertices should contain theSameElementsInOrderAs Array(3.0f, 3.0f, 3.0f, 1.0f, 1.0f, 1.0f, 2.0f, 2.0f, 2.0f)
-      actual.color should contain theSameElementsInOrderAs Array(0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f)
+      actual.vertices should contain theSameElementsInOrderAs Array(1.0f, 1.0f, 0.0f, 4.0f, 1.0f, 0.0f, 4.0f, 4.0f, 0.0f, 1.0f,
+        1.0f, 0.0f, 4.0f, 4.0f, 0.0f, 1.0f, 4.0f, 0.0f)
+      actual.color should contain theSameElementsInOrderAs Array(0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f, 0.3f, 0.4f,
+        0.5f, 0.3f, 0.4f, 0.5f, 0.3f, 0.4f, 0.5f)
     }
   }
 }


### PR DESCRIPTION
The following types can be read and transformed to a internal data structure:
  - vertices, and faces
  - vertices, normals and faces
  - vertices, textures and faces
  - vertices, normals, textures and faces

Also the smoothGroup was added for lights later.