### PR TITLE
Fix bug with path and filename when used as framework in another project

### DIFF
--- a/src/main/scala/org/sorted/chaos/wavefront/utilities/FileReader.scala
+++ b/src/main/scala/org/sorted/chaos/wavefront/utilities/FileReader.scala
@@ -8,14 +8,25 @@ import scala.util.{ Failure, Success, Try }
 object FileReader {
   private final val Log = LoggerFactory.getLogger(this.getClass)
 
-  def read(filename: String): Vector[String] =
-    Try(Source.fromResource(filename).getLines().toVector) match {
-      case Success(lines) => lines
+  def read(filename: String): Vector[String] = {
+    val maybeStream = Try(this.getClass.getResourceAsStream(filename))
+    maybeStream match {
       case Failure(exception) =>
         Log.error(
-          s"An error occurred during reading '$filename'.",
+          s"Can't create an InputStream from file: '$filename'. Exception was: ",
           exception
         )
-        Vector.empty
+        Vector.empty[String]
+      case Success(inStream) =>
+        Try(Source.fromInputStream(inStream).getLines().toVector) match {
+          case Success(lines) => lines
+          case Failure(exception) =>
+            Log.error(
+              s"An error occurred during reading '$filename'. Exception was: ",
+              exception
+            )
+            Vector.empty[String]
+        }
     }
+  }
 }

--- a/src/test/scala/org/sorted/chaos/wavefront/utilities/FileReaderTest.scala
+++ b/src/test/scala/org/sorted/chaos/wavefront/utilities/FileReaderTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.{Matchers, WordSpec}
 class FileReaderTest extends WordSpec with Matchers {
   "A FileReader" should {
     "read a text file" in {
-      val actual = FileReader.read("text.txt")
+      val actual = FileReader.read("/text.txt")
       actual shouldBe Vector("1. line", "2. line", "end of file")
     }
     "return an empty Vector, if the file does not exist" in {


### PR DESCRIPTION
The problem is the following... for reading a file from resources
there are two options
* Source.fromResource("myAwesome.txt")
* getClass.getResourceAsStream("/myAwesome.txt")
The problem is this missing "/" in front of the filename. To have things
similar the FileReader had be modified. If you use Source.fromResource
with "/" a NPE is thrown.